### PR TITLE
fix(docker): update Go version to 1.24 for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 构建阶段
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
fix: update Go toolchain to 1.24 in Docker builder

- Changed FROM golang:1.21-alpine to golang:1.24-alpine AS builder
- Resolves "go.mod requires go >= 1.24" error during go mod download
- Ensures Docker build uses same Go version as development environment
- Prevents toolchain version mismatch issues in CI/CD pipelines